### PR TITLE
Do not use Regions enum to create AWS clients

### DIFF
--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSClientFactory.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSClientFactory.java
@@ -33,19 +33,18 @@ public class AWSClientFactory implements Serializable {
             final String region,
             final String pluginUserAgentPrefix) {
 
-        final Region awsRegion = Region.getRegion(Regions.fromName(region));
         final AWSClients aws;
 
         if (StringUtils.isEmpty(awsAccessKey) && StringUtils.isEmpty(awsSecretKey)) {
             aws = AWSClients.fromDefaultCredentialChain(
-                    awsRegion,
+                    region,
                     proxyHost,
                     proxyPort,
                     pluginUserAgentPrefix);
         }
         else {
             aws = AWSClients.fromBasicCredentials(
-                    awsRegion,
+                    region,
                     awsAccessKey,
                     awsSecretKey,
                     proxyHost,

--- a/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
+++ b/src/main/java/com/amazonaws/codepipeline/jenkinsplugin/AWSCodePipelineSCM.java
@@ -166,12 +166,13 @@ public class AWSCodePipelineSCM extends hudson.scm.SCM {
         final String projectName = Validation.sanitize(project.getName().trim());
 
         LoggingHelper.log(listener, "Polling for jobs for action type id: ["
-                + "Owner: %s, Category: %s, Provider: %s, Version: %s, ProjectName: %s]",
+                + "Owner: %s, Category: %s, Provider: %s, Version: %s, ProjectName: %s] in AWS region %s",
                 actionTypeId.getOwner(),
                 actionTypeId.getCategory(),
                 actionTypeId.getProvider(),
                 actionTypeId.getVersion(),
-                project.getName());
+                project.getName(),
+                region);
 
         return pollForJobs(projectName, actionTypeId, listener);
     }


### PR DESCRIPTION
We shouldn't use enum. 

Otherwise, the conversion fails if the SDK version doesn't support the region. That will be the case when AWS releases new regions, but customers don't update the plugin

